### PR TITLE
Add deterministic PDF extractor module using pdfplumber

### DIFF
--- a/helpers/pdf_extraction/__init__.py
+++ b/helpers/pdf_extraction/__init__.py
@@ -1,0 +1,3 @@
+from helpers.pdf_extraction.annual_report_pdf import AnnualReportPDF
+
+__all__ = ["AnnualReportPDF"]

--- a/helpers/pdf_extraction/annual_report_pdf.py
+++ b/helpers/pdf_extraction/annual_report_pdf.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from helpers.pdf_extraction.text_extractor import extract_text_sections_impl
+from helpers.pdf_extraction.table_extractor import extract_tables_impl
+
+
+class AnnualReportPDF:
+    """
+    PDF-level abstraction.
+    Delegates extraction logic to helper modules.
+    """
+
+    def __init__(self, pdf_path: str):
+        self.pdf_path = pdf_path
+        self.pdf_name = Path(pdf_path).name
+
+    def extract_text_sections(self):
+        return extract_text_sections_impl(self.pdf_path, self.pdf_name)
+
+    def extract_tables(self):
+        return extract_tables_impl(self.pdf_path, self.pdf_name)
+
+    def extract_all(self):
+        return {
+            "pdf_name": self.pdf_name,
+            "text_sections": self.extract_text_sections(),
+            "tables": self.extract_tables()
+        }

--- a/helpers/pdf_extraction/table_extractor.py
+++ b/helpers/pdf_extraction/table_extractor.py
@@ -1,0 +1,37 @@
+import pdfplumber
+from typing import List, Dict
+
+
+def extract_tables_impl(pdf_path: str, pdf_name: str) -> List[Dict]:
+    """
+    Extracts tables from each page using pdfplumber's
+    built-in table extraction.
+    """
+    tables_data = []
+    table_id_counter = 1
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for page_no, page in enumerate(pdf.pages, start=1):
+            tables = page.extract_tables()
+
+            if not tables:
+                continue
+
+            for table in tables:
+                if not table or len(table) < 1:
+                    continue
+
+                headers = table[0]
+                rows = table[1:]
+
+                tables_data.append({
+                    "pdf_name": pdf_name,
+                    "page_no": page_no,
+                    "table_id": f"table_{table_id_counter}",
+                    "headers": headers,
+                    "rows": rows
+                })
+
+                table_id_counter += 1
+
+    return tables_data

--- a/helpers/pdf_extraction/text_extractor.py
+++ b/helpers/pdf_extraction/text_extractor.py
@@ -1,0 +1,24 @@
+import pdfplumber
+from typing import List, Dict
+
+
+def extract_text_sections_impl(pdf_path: str, pdf_name: str) -> List[Dict]:
+    """
+    Extracts page-wise text from a PDF using pdfplumber.
+    Deterministic and reproducible.
+    """
+    extracted = []
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for page_no, page in enumerate(pdf.pages, start=1):
+            text = page.extract_text() or ""
+
+            extracted.append({
+                "pdf_name": pdf_name,
+                "page_no": page_no,
+                "text": text.strip(),
+                # Optional metadata for downstream use
+                "char_count": len(text),
+            })
+
+    return extracted

--- a/run_extraction.py
+++ b/run_extraction.py
@@ -1,0 +1,20 @@
+import json
+from helpers.pdf_extraction.annual_report_pdf import AnnualReportPDF
+from pathlib import Path
+
+OUTPUT_PATH = Path("outputs/text_extracted.json")
+PDF_PATH = r"C:\Users\hedet\Downloads\ITC Limited Annual Report 2024.pdf"  # change as needed
+
+
+def main():
+    pdf = AnnualReportPDF(PDF_PATH)
+    extracted_data = pdf.extract_all()
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(extracted_data, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a deterministic PDF extraction helper module using pdfplumber.

Features:
- Page-wise text extraction with metadata (pdf_name, page_no)
- Table extraction with metadata (pdf_name, page_no, table_id, headers, rows)
- AnnualReportPDF class coordinating extraction logic
- JSON output stored in outputs/text_extracted.json
- Reference runner: run_extraction.py

Notes:
- Fully deterministic; does not use any agents or LLMs
- .env and outputs/ are ignored
- Tested on local PDF
